### PR TITLE
Basic I18n implemented

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,3 +70,5 @@ gem "ruby-openai", "~> 8.1"
 gem "dotenv-rails", "~> 3.1", groups: [ :development, :test ]
 
 gem "cssbundling-rails", "~> 1.4"
+
+gem "devise-i18n", "~> 1.14"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,9 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.14.0)
+      devise (>= 4.9.0)
+      rails-i18n
     dotenv (3.1.8)
     dotenv-rails (3.1.8)
       dotenv (= 3.1.8)
@@ -272,6 +275,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (8.0.1)
+      i18n (>= 0.7, < 2)
+      railties (>= 8.0.0, < 9)
     railties (8.0.2)
       actionpack (= 8.0.2)
       activesupport (= 8.0.2)
@@ -411,6 +417,7 @@ DEPENDENCIES
   cssbundling-rails (~> 1.4)
   debug
   devise (~> 4.9)
+  devise-i18n (~> 1.14)
   dotenv-rails (~> 3.1)
   foreman
   importmap-rails

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -25,7 +25,7 @@ class RecipesController < ApplicationController
       @recipe.image_url = service_response[:image_url] # Define a URL da imagem da receita com base na resposta do serviço
 
       if @recipe.save
-        redirect_to @recipe, notice: "Sua receita foi gerada com sucesso!" # Redireciona para a receita recém-criada com uma mensagem de sucesso
+        redirect_to @recipe, notice: t("recipes.create.success") # Redireciona para a receita recém-criada com uma mensagem de sucesso
       else
         render :new, status: :unprocessable_content # Renderiza o formulário novamente em caso de erro
       end
@@ -38,7 +38,7 @@ class RecipesController < ApplicationController
       puts e.backtrace.join("\n")
       puts "-----------------------------"
 
-      flash[:alert] = "A geração da sua receita demorou demais para responder. Por favor, tente novamente." # Captura qualquer erro e exibe uma mensagem de alerta
+      flash[:alert] = t("recipes.create.error") # Captura qualquer erro e exibe uma mensagem de alerta
       render :new, status: :unprocessable_content # Renderiza o formulário novamente em caso de erro
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,8 @@ module EasyFood
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # Configuração de localização
+    config.i18n.default_locale = :'pt-BR'
   end
 end

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,0 +1,10 @@
+pt-BR:
+  recipes:
+    new:
+      title: "Gerar Nova Receita"
+      description: "Descreva os ingredientes que você tem a disposição. Seja específico para melhores resultados!"
+      ingredients_label: "Meus Ingredientes:"
+      submit_button: "Gerar Receita"
+    create:
+      success: "Sua receita foi gerada com sucesso!"
+      error: "A geração da sua receita demorou demais para responder. Por favor, tente novamente."


### PR DESCRIPTION
This pull request introduces localization support for the application, focusing on Brazilian Portuguese (`pt-BR`). The main changes include setting the default locale, adding translated messages for recipe creation, and updating user-facing messages to use the new translations.

Localization setup:

* Set the default locale to Brazilian Portuguese (`pt-BR`) in `config/application.rb`.
* Added the `devise-i18n` gem to support internationalization for authentication-related messages in the `Gemfile`.

Translation integration:

* Created a new locale file `config/locales/pt-BR.yml` with translations for recipe creation and error messages.
* Updated success and error messages in `recipes_controller.rb` to use translation keys instead of hardcoded strings. [[1]](diffhunk://#diff-31617e13205c601fb6138ffeaa8531e55c20da34348924c088b298eb7392b547L28-R28) [[2]](diffhunk://#diff-31617e13205c601fb6138ffeaa8531e55c20da34348924c088b298eb7392b547L41-R41)