### PR TITLE
Active Storage to image implemented

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -18,16 +18,12 @@ class RecipesController < ApplicationController
 
     begin # Inicia o bloco de tratamento de exceções
 
-      service_response = RecipeGeneratorService.new(@recipe.ingredients).call # Chama o serviço para gerar a receita
-
-      @recipe.title = service_response[:title] # Define o título da receita com base na resposta do serviço
-      @recipe.instructions = service_response[:instructions] # Define as instruções da receita com base na resposta do serviço
-      @recipe.image_url = service_response[:image_url] # Define a URL da imagem da receita com base na resposta do serviço
+      RecipeGeneratorService.new(@recipe).call # Chama o serviço para gerar a receita
 
       if @recipe.save
-        redirect_to @recipe, notice: t("recipes.create.success") # Redireciona para a receita recém-criada com uma mensagem de sucesso
+        redirect_to @recipe, notice: t("recipes.create.success")
       else
-        render :new, status: :unprocessable_content # Renderiza o formulário novamente em caso de erro
+        render :new, status: :unprocessable_content
       end
 
     rescue Exception => e

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,3 +1,4 @@
 class Recipe < ApplicationRecord
   belongs_to :user
+  has_one_attached :photo
 end

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -10,8 +10,8 @@
       <div class="col-md-6 col-lg-4 mb-4"> <!-- Em telas médias cada card ocupará 2 linhas e em telas grandes 3 linhas -->
         <%= link_to recipe, class: "text-decoration-none" do %> <!-- Link para a receita -->
           <div class="card h-100 shadow-sm card-hover"> <!-- Garante que todos os cards tenham o mesmo tamanho -->
-            <% if recipe.image_url.present? %>
-              <%= image_tag recipe.image_url, class: "card-img-top", alt: recipe.title %>
+            <% if recipe.photo.attached? %>
+              <%= image_tag recipe.photo, class: "card-img-top", alt: recipe.title %>
             <% end %>
             <div class="card-body">
               <h5 class="card-title text-dark"><%= recipe.title %></h5>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -5,9 +5,9 @@
       <div class="card-body">
 
         <%# --- IMAGEM DENTRO DO CARD-BODY --- %>
-        <% if @recipe.image_url.present? %> <!-- Verifica se a imagem está presente -->
+        <% if @recipe.photo.attached? %> <!-- Verifica se a imagem está presente -->
           <div class="text-center"> <!-- Centraliza a imagem -->
-            <%= image_tag @recipe.image_url,
+            <%= image_tag @recipe.photo,
                           class: "img-fluid rounded-3 mb-4 w-75",
                           alt: @recipe.title %>
           </div>

--- a/db/migrate/20250812224622_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250812224622_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_11_174810) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_12_224622) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "recipes", force: :cascade do |t|
     t.string "title"
@@ -37,5 +65,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_11_174810) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "recipes", "users"
 end


### PR DESCRIPTION
This pull request introduces a major change to how recipe images are handled: instead of storing image URLs in the database, images generated by the AI are now attached directly to recipes using Rails Active Storage. The service responsible for generating recipes has been refactored to update the recipe object directly and attach the generated image file. The views and database schema have been updated accordingly.

**Image Storage and Model Updates**
* Added `has_one_attached :photo` to the `Recipe` model to enable Active Storage for recipe images.
* Added the Active Storage migration and updated `db/schema.rb` to include the necessary tables and foreign keys for blob and attachment management. [[1]](diffhunk://#diff-ac1e4d61e04271a3504b4805c62ac974294ee708fe1e11a51f22c9ae7956cd24R1-R57) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R44) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R68-R69)

**Recipe Generation Service Refactor**
* Refactored `RecipeGeneratorService` to accept a `Recipe` object, update its attributes directly, and attach the generated image using Active Storage instead of returning a hash with an image URL.
* The controller now calls the service with the recipe object and no longer expects image URLs or other attributes in the response.

**View Updates**
* Updated recipe index and show views to display images using `recipe.photo` if attached, instead of relying on an `image_url`. [[1]](diffhunk://#diff-9e9c659db8c09c302e8e6d3a7705b0172b23d27edcf5c09c25ac7f086ff8d139L13-R14) [[2]](diffhunk://#diff-b0e972cf30eafd0a0fab0ca3ea7fe54892790201f707f9f18c909958456b65f0L8-R10)