### PR TITLE
Homepage 'Popular Recipes' with login

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -45,20 +45,53 @@
 <%# --- Seção de Últimas Receitas --- %>
 <div class="container px-4 py-5">
   <h2 class="pb-2 border-bottom"><%= t('.latest_recipes_title') %></h2>
-  <div class="row mt-4">
-    <% @latest_recipes.each do |recipe| %>
-      <div class="col-md-6 col-lg-4 mb-4">
-        <%= link_to recipe, class: "text-decoration-none" do %>
-          <div class="card h-100 shadow-sm card-hover">
+
+  <%# Verifica se o usuário está logado %>
+  <% if user_signed_in? %>
+
+    <%# SE ESTIVER LOGADO: Mostra a galeria de cards normal %>
+    <div class="row mt-4">
+      <% @latest_recipes.each do |recipe| %>
+        <div class="col-md-6 col-lg-4 mb-4">
+          <%= link_to recipe, class: "text-decoration-none" do %>
+            <div class="card h-100 shadow-sm card-hover">
+              <% if recipe.photo.attached? %>
+                <%= image_tag recipe.photo, class: "card-img-top", alt: recipe.title %>
+              <% end %>
+              <div class="card-body">
+                <h5 class="card-title text-dark"><%= recipe.title %></h5>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+  <% else %>
+
+    <%# SE NÃO ESTIVER LOGADO: Mostra uma sobreposição de "login necessário" %>
+    <div class="row mt-4 position-relative">
+      <%# Cards com efeito de desfoque %>
+      <% @latest_recipes.first(3).each do |recipe| %>
+        <div class="col-md-6 col-lg-4 mb-4">
+          <div class="card h-100 shadow-sm" style="filter: blur(4px); opacity: 0.6;">
             <% if recipe.photo.attached? %>
-              <%= image_tag recipe.photo, class: "card-img-top", alt: recipe.title %>
+              <%= image_tag recipe.photo, class: "card-img-top", alt: "Receita bloqueada" %>
             <% end %>
             <div class="card-body">
               <h5 class="card-title text-dark"><%= recipe.title %></h5>
             </div>
           </div>
-        <% end %>
+        </div>
+      <% end %>
+
+      <%# Sobreposição com a chamada para ação %>
+      <div class="position-absolute top-50 start-50 translate-middle text-center bg-light p-4 rounded-3 shadow" style="width: 80%;">
+        <p><%= t('.login_wall.subtitle') %></p>
+        <%= link_to t('.login_wall.sign_up_button'), new_user_registration_path, class: "btn btn-primary" %>
+        <%= link_to t('.login_wall.sign_in_button'), new_user_session_path, class: "btn btn-secondary" %>
       </div>
-    <% end %>
-  </div>
+    </div>
+
+  <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,11 @@ en:
       popular_recipes_subtitle: "The recipes the community is making the most with today's trending ingredients."
       top_ingredients_title: "Trending Ingredients"
       latest_recipes_title: "Latest Added Recipes"
+      login_wall:
+        title: "Exclusive Members Only Access"
+        subtitle: "Sign up or log in to see the latest recipes and access all features."
+        sign_up_button: "Create Account"
+        sign_in_button: "Log In"
 
     about:
       hero_title_html: "Say goodbye to<br>\"what are we eating today?\""

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -9,6 +9,11 @@ es:
       popular_recipes_subtitle: "Las recetas que la comunidad más está preparando con los ingredientes del momento."
       top_ingredients_title: "Ingredientes en Tendencia"
       latest_recipes_title: "Últimas Recetas Añadidas"
+      login_wall:
+        title: "Acceso Exclusivo para Miembros"
+        subtitle: "Regístrate o inicia sesión para ver las últimas recetas y tener acceso a todas las funcionalidades."
+        sign_up_button: "Crear Cuenta"
+        sign_in_button: "Iniciar Sesión"
 
     about:
       hero_title_html: "Dile adiós al<br>\"¿qué comemos hoy?\""

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -9,6 +9,11 @@ pt-BR:
       popular_recipes_subtitle: "As receitas que a comunidade mais está fazendo com os ingredientes do momento."
       top_ingredients_title: "Ingredientes em Alta"
       latest_recipes_title: "Últimas Receitas Adicionadas"
+      login_wall:
+        title: "Acesso Exclusivo para Membros"
+        subtitle: "Cadastre-se ou faça login para ver as receitas mais recentes e ter acesso a todas as funcionalidades."
+        sign_up_button: "Criar Conta"
+        sign_in_button: "Fazer Login"
     about:
       about:
       hero_title_html: "Diga adeus ao<br>\"o que vamos comer hoje?\""


### PR DESCRIPTION
This pull request introduces a "login wall" feature for the latest recipes section on the home page. Now, only logged-in users can see the full list of latest recipes, while visitors see a blurred preview and a prompt to sign up or log in. The necessary translations for this feature have also been added in English, Spanish, and Portuguese.

**Home page UI changes:**

* Updated `app/views/pages/home.html.erb` to show the full latest recipes gallery only to logged-in users; guests see a blurred preview of three recipes with an overlay prompting them to log in or sign up. [[1]](diffhunk://#diff-8c80b6626c38cda1f173a92f4709a673ee5ed4bbb14d96d20afefecd730b029aR48-R52) [[2]](diffhunk://#diff-8c80b6626c38cda1f173a92f4709a673ee5ed4bbb14d96d20afefecd730b029aR69-R96)

**Localization:**

* Added `login_wall` translations (title, subtitle, sign up, and sign in buttons) to `config/locales/en.yml`, `config/locales/es.yml`, and `config/locales/pt-BR.yml` for the new login wall overlay. [[1]](diffhunk://#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7R12-R16) [[2]](diffhunk://#diff-4bbf4ee302c9607c80408361708b8b9fde3ee7afc5b505bfd69d429dd433f915R12-R16) [[3]](diffhunk://#diff-6ae88d4841cc9662332db5da2228b9a7bc0eaa16328024e4158b074e6141940aR12-R16)