### PR TITLE
I18n fullapp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,3 +72,5 @@ gem "dotenv-rails", "~> 3.1", groups: [ :development, :test ]
 gem "cssbundling-rails", "~> 1.4"
 
 gem "devise-i18n", "~> 1.14"
+
+gem "rails-i18n", "~> 8.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -427,6 +427,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2)
+  rails-i18n (~> 8.0)
   rubocop-rails-omakase
   ruby-openai (~> 8.1)
   selenium-webdriver

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -18,7 +18,7 @@ class RecipesController < ApplicationController
 
     begin # Inicia o bloco de tratamento de exceções
 
-      RecipeGeneratorService.new(@recipe).call # Chama o serviço para gerar a receita
+      RecipeGeneratorService.new(@recipe, I18n.locale).call # Chama o serviço para gerar a receita
 
       if @recipe.save
         redirect_to @recipe, notice: t(".success")

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -9,8 +9,9 @@ class RecipesController < ApplicationController
     @recipe = current_user.recipes.find(params[:id]) # Encontra a receita específica do usuário logado
 
     # Prepara as variáveis para exibição com o conteúdo original por padrão
-    @display_title = @recipe.display_title
-    @display_instructions = @recipe.display_instructions
+    @display_title = @recipe.title
+    @display_ingredients = @recipe.ingredients
+    @display_instructions = @recipe.instructions
 
     # Verifica se o idioma da interface é diferente do padrão (pt-BR)
     if I18n.locale != I18n.default_locale
@@ -19,10 +20,10 @@ class RecipesController < ApplicationController
       # Se a tradução foi encontrada ou criada com sucesso, usa os textos traduzidos
       if translation
         @display_title = translation.title # Exibe o título traduzido
+        @display_ingredients = translation.ingredients # Exibe os ingredientes traduzidos
         @display_instructions = translation.instructions # Exibe as instruções traduzidas
       end
     end
-
   end
 
   def new

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -7,6 +7,22 @@ class RecipesController < ApplicationController
 
   def show
     @recipe = current_user.recipes.find(params[:id]) # Encontra a receita específica do usuário logado
+
+    # Prepara as variáveis para exibição com o conteúdo original por padrão
+    @display_title = @recipe.display_title
+    @display_instructions = @recipe.display_instructions
+
+    # Verifica se o idioma da interface é diferente do padrão (pt-BR)
+    if I18n.locale != I18n.default_locale
+      translation = @recipe.translation_for(I18n.locale) # Pede ao modelo para buscar ou criar uma tradução
+
+      # Se a tradução foi encontrada ou criada com sucesso, usa os textos traduzidos
+      if translation
+        @display_title = translation.title # Exibe o título traduzido
+        @display_instructions = translation.instructions # Exibe as instruções traduzidas
+      end
+    end
+
   end
 
   def new

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,4 +1,5 @@
 class Recipe < ApplicationRecord
   belongs_to :user
   has_one_attached :photo
+  has_many :recipe_translations, dependent: :destroy
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -2,4 +2,23 @@ class Recipe < ApplicationRecord
   belongs_to :user
   has_one_attached :photo
   has_many :recipe_translations, dependent: :destroy
+
+  def translation_for(locale) # Método que busca a tradução para um determinado idioma
+    # Procura por uma tradução que já exista no banco de dados
+    translation = recipe_translations.find_by(locale: locale.to_s)
+    translation if translation.present?
+
+    # Se não houver tradução, gera uma nova
+    translated_data = RecipeTranslatorService.new(self, locale).call
+
+    # Se a tradução falhar (serviço retornou nil), não faz nada
+    return nil unless translated_data
+
+    # Salva a nova tradução no banco de dados para uso futuro
+    recipe_translations.create(
+      locale: locale.to_s,
+      title: translated_data[:title],
+      instructions: translated_data[:instructions]
+    )
+  end
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -18,6 +18,7 @@ class Recipe < ApplicationRecord
     recipe_translations.create(
       locale: locale.to_s,
       title: translated_data[:title],
+      ingredients: translated_data[:ingredients],
       instructions: translated_data[:instructions]
     )
   end

--- a/app/models/recipe_translation.rb
+++ b/app/models/recipe_translation.rb
@@ -1,0 +1,3 @@
+class RecipeTranslation < ApplicationRecord
+  belongs_to :recipe
+end

--- a/app/services/recipe_generator_service.rb
+++ b/app/services/recipe_generator_service.rb
@@ -1,10 +1,11 @@
 require "open-uri" # Necessário para fazer download da imagem gerada
 
 class RecipeGeneratorService
-  def initialize(recipe)
+  def initialize(recipe, locale)
     @recipe = recipe # Armazena a receita fornecida
     @ingredients = recipe.ingredients # Extrai os ingredientes da receita
     @client = OpenAI::Client.new # Inicializa o cliente OpenAI com a configuração definida no initializer
+    @locale = locale # Armazena o idioma atual
   end
 
   def call # Método principal que gera a receita
@@ -23,7 +24,7 @@ class RecipeGeneratorService
     @recipe.title = recipe_data[:title]
     @recipe.instructions = recipe_data[:instructions]
 
-    image_prompt = "Fotografia realista e de alta qualidade de um prato de #{@recipe.title} incrivelmente apetitoso. A iluminação é natural e suave, com foco nítido nos detalhes do prato e um fundo levemente desfocado. Parece uma foto profissional de comida, com texturas realistas, sem artefatos digitais." # Cria o prompt de imagem para a geração da foto
+    image_prompt = "#{I18n.t('.image_prompt_prefix')} #{@recipe.title}" # Cria o prompt de imagem para a geração da foto
     image_response = @client.images.generate(
       parameters: {
         model: "dall-e-3",
@@ -53,12 +54,11 @@ class RecipeGeneratorService
       Você é um chef de cozinha especializado em criar receitas deliciosas, saudáveis, criativas e fáceis de preparar. Sua tarefa é gerar uma receita deliciosa e fácil de seguir usando apenas os ingredientes fornecidos.
 
       Siga estritamente as seguintes regras:
-      1. A resposta deve ser na língua que o usuário está falando.
-      2. A resposta DEVE ser apenas o texto da receita, sem nenhuma introdução ou comentário seu.
-      3. O formato da resposta DEVE ser exatamente:
-
+      1. A resposta DEVE ser apenas o texto da receita, sem nenhuma introdução ou comentário seu.
+      2. O formato da resposta DEVE ser exatamente:
       TÍTULO: [aqui o título criativo da receita]
       INSTRUÇÕES: [aqui o passo a passo do modo de preparo da receita, com cada passo numerado]
+      3. Gere a receita inteira (título e instruções) no seguinte idioma: #{@locale}.
 
       Ingredientes fornecidos: #{@ingredients}
     PROMPT

--- a/app/services/recipe_translator_service.rb
+++ b/app/services/recipe_translator_service.rb
@@ -32,6 +32,7 @@ class RecipeTranslatorService
       3. O formato da resposta DEVE ser exatamente:
 
       TÍTULO: [aqui o título traduzido]
+      INGREDIENTES: [aqui a lista de ingredientes traduzida]
       INSTRUÇÕES: [aqui as instruções traduzidas]
 
       Idioma Alvo para a Tradução: #{@target_locale}
@@ -40,17 +41,19 @@ class RecipeTranslatorService
       Texto Original para Traduzir:
 
       TÍTULO: #{@recipe.title}
+      INGREDIENTES: #{@recipe.ingredients}
       INSTRUÇÕES: #{@recipe.instructions}
     PROMPT
   end
 
   def parse_translated_text(text)
     # Retorna nulo se a resposta da IA não vier no formato esperado
-    return nil unless text&.include?("TÍTULO:") && text&.include?("INSTRUÇÕES:")
+    return nil unless text&.include?("TÍTULO:") && text&.include?("INGREDIENTES:") && text&.include?("INSTRUÇÕES:")
 
-    title = text.match(/TÍTULO:(.*?)INSTRUÇÕES:/m)[1].strip
+    title = text.match(/TÍTULO:(.*?)INGREDIENTES:/m)[1].strip
+    ingredients = text.match(/INGREDIENTES:(.*?)INSTRUÇÕES:/m)[1].strip
     instructions = text.match(/INSTRUÇÕES:(.*)/m)[1].strip
 
-    { title: title, instructions: instructions }
+    { title: title, ingredients: ingredients, instructions: instructions }
   end
 end

--- a/app/services/recipe_translator_service.rb
+++ b/app/services/recipe_translator_service.rb
@@ -1,0 +1,56 @@
+class RecipeTranslatorService
+  def initialize(recipe, target_locale)
+    @recipe = recipe
+    @target_locale = target_locale
+    @client = OpenAI::Client.new
+  end
+
+  def call # Método principal que gera a tradução da receita
+    prompt = create_translation_prompt
+
+    response = @client.chat(
+      parameters: {
+        model: "gpt-3.5-turbo",
+        messages: [{ role: "user", content: prompt }],
+        temperature: 0.3 # Temperatura mais baixa para traduções mais literais
+      }
+    )
+
+    translated_text = response.dig("choices", 0, "message", "content")
+    parse_translated_text(translated_text) # Método que analisa o texto traduzido
+  end
+
+  private
+
+  def create_translation_prompt
+    <<~PROMPT
+      Você é um assistente de tradução especializado em receitas culinárias. Sua tarefa é traduzir o título e as instruções de uma receita para o idioma alvo.
+
+      Siga estritamente as seguintes regras:
+      1. A resposta DEVE ser apenas a tradução, sem nenhuma introdução ou comentário seu.
+      2. Mantenha a formatação original das instruções (numeração, quebras de linha).
+      3. O formato da resposta DEVE ser exatamente:
+
+      TÍTULO: [aqui o título traduzido]
+      INSTRUÇÕES: [aqui as instruções traduzidas]
+
+      Idioma Alvo para a Tradução: #{@target_locale}
+
+      ---
+      Texto Original para Traduzir:
+
+      TÍTULO: #{@recipe.title}
+      INSTRUÇÕES: #{@recipe.instructions}
+    PROMPT
+  end
+
+  def parse_translated_text(text)
+    # Retorna nulo se a resposta da IA não vier no formato esperado
+    return nil unless text&.include?("TÍTULO:") && text&.include?("INSTRUÇÕES:")
+
+    title = text.match(/TÍTULO:(.*?)INSTRUÇÕES:/m)[1].strip
+    instructions = text.match(/INSTRUÇÕES:(.*)/m)[1].strip
+
+    { title: title, instructions: instructions }
+  end
+end

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -9,12 +9,12 @@
           <div class="text-center"> <!-- Centraliza a imagem -->
             <%= image_tag @recipe.photo,
                           class: "img-fluid rounded-3 mb-4 w-75",
-                          alt: @recipe.title %>
+                          alt: @display_title %>
           </div>
         <% end %>
         <%# ------------------------------------ %>
 
-        <h1 class="card-title h2"><%= @recipe.title %></h1> <!-- Título da receita -->
+        <h1 class="card-title h2"><%= @display_title %></h1> <!-- Título da receita -->
 
         <hr>
 
@@ -25,7 +25,7 @@
 
         <h3 class="h5 text-muted"><%= t('.instructions_title') %></h3> <!-- Subtítulo para modo de preparo -->
         <div class="card-text"> <!-- Texto do modo de preparo -->
-          <%= simple_format(@recipe.instructions) %>
+          <%= simple_format(@display_instructions) %>
         </div>
       </div>
     </div>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -20,7 +20,7 @@
 
         <h3 class="h5 text-muted"><%= t('.ingredients_title') %></h3> <!-- Subtítulo para ingredientes -->
         <p class="card-text mb-4"> <!-- Parágrafo para ingredientes -->
-          <%= @recipe.ingredients %>
+          <%= @display_ingredients %>
         </p>
 
         <h3 class="h5 text-muted"><%= t('.instructions_title') %></h3> <!-- Subtítulo para modo de preparo -->

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,3 +62,5 @@ en:
       created_by: "A project created by Henrique Motta."
       about: "About"
       language: "Language:"
+
+  image_prompt_prefix: "A high-quality, realistic photograph of a plate of"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -64,3 +64,6 @@ es:
       created_by: "Un proyecto creado por Henrique Motta."
       about: "Sobre"
       language: "Idioma:"
+
+  image_prompt_prefix: "Una fotografía realista y de alta calidad de un plato de"
+

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -62,3 +62,5 @@ pt-BR:
       created_by: "Um projeto criado por Henrique Motta."
       about: "Sobre"
       language: "Idioma:"
+
+  image_prompt_prefix: "Fotografia realista e de alta qualidade de um prato de"

--- a/db/migrate/20250819222001_create_recipe_translations.rb
+++ b/db/migrate/20250819222001_create_recipe_translations.rb
@@ -1,0 +1,12 @@
+class CreateRecipeTranslations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :recipe_translations do |t|
+      t.references :recipe, null: false, foreign_key: true
+      t.string :locale
+      t.string :title
+      t.text :instructions
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250820032109_add_ingredients_to_recipe_translations.rb
+++ b/db/migrate/20250820032109_add_ingredients_to_recipe_translations.rb
@@ -1,0 +1,5 @@
+class AddIngredientsToRecipeTranslations < ActiveRecord::Migration[8.0]
+  def change
+    add_column :recipe_translations, :ingredients, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_19_222001) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_20_032109) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -49,6 +49,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_19_222001) do
     t.text "instructions"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "ingredients"
     t.index ["recipe_id"], name: "index_recipe_translations_on_recipe_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_14_154615) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_19_222001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -42,6 +42,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_14_154615) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "recipe_translations", force: :cascade do |t|
+    t.bigint "recipe_id", null: false
+    t.string "locale"
+    t.string "title"
+    t.text "instructions"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recipe_id"], name: "index_recipe_translations_on_recipe_id"
+  end
+
   create_table "recipes", force: :cascade do |t|
     t.string "title"
     t.text "ingredients"
@@ -68,5 +78,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_14_154615) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "recipe_translations", "recipes"
   add_foreign_key "recipes", "users"
 end

--- a/test/fixtures/recipe_translations.yml
+++ b/test/fixtures/recipe_translations.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  recipe: one
+  locale: MyString
+  title: MyString
+  instructions: MyText
+
+two:
+  recipe: two
+  locale: MyString
+  title: MyString
+  instructions: MyText

--- a/test/models/recipe_translation_test.rb
+++ b/test/models/recipe_translation_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RecipeTranslationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This pull request adds multi-language support for recipes by introducing recipe translations, updating the recipe generation and display logic to be locale-aware, and providing the necessary database, backend, and frontend changes. The main improvements include automatic translation of recipes, storage of translations, and dynamic display based on the user's selected language.

**Internationalization and Translation Support:**
- Added the `rails-i18n` gem to enable broader Rails internationalization features.
- Created the `RecipeTranslation` model and associated database migrations to store translated titles, ingredients, and instructions for each recipe and locale. [[1]](diffhunk://#diff-7a3cb757ed07389f055beda4c21c0a1896867a30ea5a0e9dffeb48cdc62e2f0eR1-R12) [[2]](diffhunk://#diff-754de2e5b08e5d3eaa286ac83d887e1b303bb3d3cfe350b192cfddd1afe9a0d2R1-R5) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R45-R55) [[4]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R82)
- Implemented the `RecipeTranslatorService` to handle translation of recipes using OpenAI, and parsing the translated response.
- Added locale-specific image prompt prefixes to translation files for improved image generation prompts. [[1]](diffhunk://#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7R65-R66) [[2]](diffhunk://#diff-4bbf4ee302c9607c80408361708b8b9fde3ee7afc5b505bfd69d429dd433f915R67-R69) [[3]](diffhunk://#diff-6ae88d4841cc9662332db5da2228b9a7bc0eaa16328024e4158b074e6141940aR65-R66)

**Recipe Generation and Display Logic:**
- Updated the `Recipe` model with a `translation_for(locale)` method to fetch or generate translations as needed, storing them for future use.
- Modified the `recipes_controller` to use translated recipe fields (`@display_title`, `@display_ingredients`, `@display_instructions`) based on the current locale, falling back to the original if no translation is available.
- Updated the recipe show view (`show.html.erb`) to display translated content dynamically.

**Recipe Generation Service Updates:**
- Changed `RecipeGeneratorService` to accept and use the current locale, ensuring generated recipes and prompts are in the user's language. [[1]](diffhunk://#diff-58a8570063cdf84b2f00328a314cc47610a6ab11b3b483288b171b890e48d22fL4-R8) [[2]](diffhunk://#diff-31617e13205c601fb6138ffeaa8531e55c20da34348924c088b298eb7392b547L21-R38) [[3]](diffhunk://#diff-58a8570063cdf84b2f00328a314cc47610a6ab11b3b483288b171b890e48d22fL26-R27) [[4]](diffhunk://#diff-58a8570063cdf84b2f00328a314cc47610a6ab11b3b483288b171b890e48d22fL56-R61)

**Testing and Fixtures:**
- Added test fixtures and a basic test file for the new `RecipeTranslation` model. [[1]](diffhunk://#diff-19a83b12fbb2194bf5d8a540bca6807ff81dfbdb2e9cbe0646216f6d0d375e70R1-R13) [[2]](diffhunk://#diff-ff881d1ae254acc3137eae9bfc009b1ee6ed9ef1cfd7546bfccb847cb97575c7R1-R7)