### PR TITLE
Public 'Popular recipes' implemented

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,12 +1,12 @@
 class RecipesController < ApplicationController
-  before_action :authenticate_user! # Garante que o usuário esteja logado para todas as ações
+  before_action :authenticate_user!, except: [ :show ] # Permite acesso público à ação "show"
 
   def index
     @recipes = current_user.recipes.order(created_at: :desc) # Exibe as receitas do usuário logado, ordenadas pela data de criação
   end
 
   def show
-    @recipe = current_user.recipes.find(params[:id]) # Encontra a receita específica do usuário logado
+    @recipe = Recipe.find(params[:id]) # Encontra a receita específica
 
     # Prepara as variáveis para exibição com o conteúdo original por padrão
     @display_title = @recipe.title


### PR DESCRIPTION
This pull request updates the `RecipesController` to allow public access to the `show` action, so users do not need to be logged in to view individual recipes. The logic for finding a recipe in the `show` action is also adjusted to allow fetching any recipe, not just those belonging to the current user.

Access control changes:

* Changed the `before_action` in `RecipesController` to allow unauthenticated users to access the `show` action.

Recipe lookup logic:

* Updated the `show` action to use `Recipe.find(params[:id])` so that any recipe can be viewed, regardless of the current user.