### PR TITLE
Add flags to language selector implemented

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,19 @@
 module ApplicationHelper
+  def language_selector_flag
+    # Verifica o idioma (locale) atual da aplicação
+    case I18n.locale
+    when :'pt-BR'
+      # Se for pt-BR, retorna as classes CSS para a bandeira do Brasil
+      "fi fi-br"
+    when :en
+      # Se for en, retorna as classes para a bandeira dos EUA
+      "fi fi-us"
+    when :es
+      # Se for es, retorna as classes para a bandeira da Espanha
+      "fi fi-es"
+    else
+      # Como um fallback seguro, retorna as classes para o ícone de globo
+      "bi bi-globe"
+    end
+  end
 end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -6,13 +6,6 @@
     <p class="mb-0">
       <%= t("layouts.footer.created_by") %> <%= link_to t("layouts.footer.about"), pages_about_path, class: "text-white" %>
     </p>
-
-    <!-- Seletor de idiomas -->
-    <div class="mt-2">
-      <small><%= t("layouts.footer.language") %></small>
-      <%= link_to "Português", url_for(locale: "pt-BR"), class: "text-white mx-1" %>
-      <%= link_to "English", url_for(locale: "en"), class: "text-white mx-1" %>
-      <%= link_to "Español", url_for(locale: "es"), class: "text-white mx-1" %>
   </div>
 </footer>
 

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -8,12 +8,34 @@
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarNav">
-      <ul class="navbar-nav ms-auto">
+      <ul class="navbar-nav ms-auto d-flex align-items-center">
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            <span class="<%= language_selector_flag %>"></span>
+          </a>
+          <ul class="dropdown-menu dropdown-menu-end">
+            <li>
+              <%= link_to url_for(locale: 'pt-BR'), class: "dropdown-item" do %>
+                <span class="fi fi-br me-2"></span> Português
+              <% end %>
+            </li>
+            <li>
+              <%= link_to url_for(locale: 'en'), class: "dropdown-item" do %>
+                <span class="fi fi-us me-2"></span> English
+              <% end %>
+            </li>
+            <li>
+              <%= link_to url_for(locale: 'es'), class: "dropdown-item" do %>
+                <span class="fi fi-es me-2"></span> Español
+              <% end %>
+            </li>
+          </ul>
+        </li>
         <% if user_signed_in? %>
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
               <i class="bi bi-person-circle"></i> <!-- Ícone de usuário do Bootstrap Icons -->
-                <%= t("layouts.navbar.welcome") %>, <%= current_user.name || current_user.email %>
+              <%= t("layouts.navbar.welcome") %>, <%= current_user.name || current_user.email %>
             </a>
             <ul class="dropdown-menu dropdown-menu-end">
               <li><a class="dropdown-item" href="<%= recipes_path %>"><%= t("layouts.navbar.my_recipes") %></a></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Chela+One&family=Roboto:wght@300;400;700&display=swap" rel="stylesheet"> <!-- Importando fontes do Google Fonts -->
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"> <!-- Importando ícones do Bootstrap Icons -->
+    <link href="https://cdn.jsdelivr.net/gh/lipis/flag-icons@7.2.3/css/flag-icons.min.css" rel="stylesheet">
+
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %> <!-- Importando o CSS do Bootstrap e outros estilos -->
     <%= javascript_importmap_tags %> <!-- Importando o JavaScript do Bootstrap e outros scripts -->
   </head>


### PR DESCRIPTION
This pull request updates the application's language selection UI by moving the language selector from the footer to a dropdown in the navbar with flag icons representing each language. It also introduces a helper method to determine the correct flag icon based on the current locale and includes the necessary flag icon styles.

Language selector improvements:

* Added a new `language_selector_flag` helper in `application_helper.rb` to return the appropriate flag icon CSS class based on the current locale.
* Replaced the old footer-based language selector with a new dropdown in the navbar, displaying flag icons for Portuguese, English, and Spanish using the new helper. [[1]](diffhunk://#diff-ecb32a9b0d6ec13e981a5b858b462c5c20f35f5d66df3a41955f82dd731e1148L11-R33) [[2]](diffhunk://#diff-4407e508d810a7552626519839c22be2704d9c83cfa5a02a36f6ffd9f9b4fcf0L9-L15)

Styling updates:

* Included the Flag Icons CSS library in `application.html.erb` to enable the use of flag icons throughout the UI.