### PR TITLE
Fix recipe generate

### DIFF
--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -2,9 +2,8 @@ class Recipe < ApplicationRecord
   belongs_to :user
   has_one_attached :photo
   has_many :recipe_translations, dependent: :destroy
-  validates :title, presence: true
   validates :ingredients, presence: true
-  validates :instructions, presence: true
+  validates :title, :instructions, presence: true, on: :update
 
   def translation_for(locale) # Método que busca a tradução para um determinado idioma
     # Procura por uma tradução que já exista no banco de dados
@@ -24,5 +23,11 @@ class Recipe < ApplicationRecord
       ingredients: translated_data[:ingredients],
       instructions: translated_data[:instructions]
     )
+  end
+
+  private
+
+  def instructions_present? # Verifica se as instruções estão presentes
+    instructions.present?
   end
 end

--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -5,7 +5,7 @@
 
     <%= form_with(model: @recipe, data: { controller: "form-submission", action: "submit->form-submission#submit" }) do |form| %> <!-- Início do formulário -->
       <div class="mb-3">
-        <%= form.label :ingredients, t('.ingredients_label'), class: "form-label" %>
+        <%= form.label :ingredients, t('recipes.new.ingredients_label'), class: "form-label" %>
         <%= form.text_area :ingredients,
                             rows: 5,
                             class: "form-control",
@@ -14,7 +14,7 @@
 
       <div class="d-grid gap-2"> <!-- Div para o botão de envio -->
         <%# Adicionando 'data-form-submission-target' ao botão %>
-        <%= form.submit t('.submit_button'), class: "btn btn-primary btn-lg", data: { form_submission_target: "button" } %>
+        <%= form.submit t('recipes.new.submit_button'), class: "btn btn-primary btn-lg", data: { form_submission_target: "button" } %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
This pull request updates recipe validation logic and improves translation usage in the recipe creation form. The most important changes are grouped below:

**Model validation improvements:**

* Updated the `Recipe` model to require `title` and `instructions` only on update, not on create, by specifying `on: :update` in the validation. This allows creating recipes without these fields initially. (`app/models/recipe.rb`)
* Added a private method `instructions_present?` to encapsulate the logic for checking if `instructions` are present. (`app/models/recipe.rb`)

**Translation and form improvements:**

* Updated the form in `recipes/new.html.erb` to use explicit translation keys (`recipes.new.ingredients_label` and `recipes.new.submit_button`) for the ingredients label and submit button, improving clarity and maintainability of translations. (`app/views/recipes/new.html.erb`) [[1]](diffhunk://#diff-46ae6841cf7e7f57cc5200d0cbaad26b0636f38d5d11ff3c7339f068c12a0301L8-R8) [[2]](diffhunk://#diff-46ae6841cf7e7f57cc5200d0cbaad26b0636f38d5d11ff3c7339f068c12a0301L17-R17)